### PR TITLE
Reducing lint ignore statements

### DIFF
--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -1,10 +1,9 @@
-/* eslint-disable camelcase */
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Settings } from '@folio/stripes/smart-components';
 import GeneralSettings from './general-settings';
 import SomeFeatureSettings from './some-feature-settings';
-
+/* eslint-disable camelcase */
 /*
   STRIPES-NEW-APP
   Your app's settings pages are defined here.

--- a/test/bigtest/network/scenarios/default.js
+++ b/test/bigtest/network/scenarios/default.js
@@ -1,6 +1,5 @@
 /* istanbul ignore file */
-/* eslint-disable no-unused-vars */
 
 // default scenario is used during `yarn start --mirage`
-export default function defaultScenario(server) {
+export default function defaultScenario() {
 }


### PR DESCRIPTION
down to 1 for camelcase so that CLI only removes what is safe after transforming files.

This will allow a newly created app to be free of eslint errors after creating an app with `stripes-cli`.