### PR TITLE
Babel 7 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change history for __uiAppName__
 
-## 1.0.0 (IN PROGRESS)
+## 1.1.0 (IN PROGRESS)
+
+* Updated to use Babel 7.
+* Updated `stripes` to v3.0.0.
+* Updated `eslint` to v6.2.1.
+
+## 1.0.0 (https://github.com/folio-org/ui-app-template/tree/v1.0.0) (2020-03-02)
 
 * New app created with stripes-cli

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@folio/stripes-core": "^4.0.0",
     "babel-eslint": "^9.0.0",
     "chai": "^4.2.0",
+    "core-js": "^3.6.1",
     "eslint": "^6.2.1",
     "mocha": "^6.1.3",
     "react": "^16.8.6",
@@ -41,6 +42,7 @@
   },
   "peerDependencies": {
     "@folio/stripes": "^3.0.0",
+    "core-js": "^3.6.1",
     "react": "*",
     "react-intl": "^2.9.0",
     "react-router-dom": "^4.3.1"

--- a/package.json
+++ b/package.json
@@ -29,19 +29,21 @@
     "mocha": "^6.1.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
+    "react-intl": "^2.9.0",
     "react-redux": "^5.1.1",
+    "react-router-dom": "^4.3.1",
     "redux": "^4.0.0",
     "regenerator-runtime": "^0.13.3",
     "sinon": "^7.3.2"
   },
   "dependencies": {
-    "prop-types": "^15.6.0",
-    "react-intl": "^2.9.0",
-    "react-router-dom": "^4.3.1"
+    "prop-types": "^15.6.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^3.0.0",
-    "react": "*"
+    "react": "*",
+    "react-intl": "^2.9.0",
+    "react-router-dom": "^4.3.1"
   },
   "stripes": {
     "type": "app",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.9.0"
   },
   "scripts": {
     "start": "stripes serve",
@@ -19,28 +19,28 @@
     "@bigtest/mirage": "^0.0.1",
     "@bigtest/mocha": "^0.5.1",
     "@bigtest/react": "^0.1.2",
-    "@folio/eslint-config-stripes": "^3.2.1",
-    "@folio/stripes": "^2.1.0",
-    "@folio/stripes-cli": "^__cliVersion__ || ^1.10.0",
-    "@folio/stripes-core": "^3.0.0",
+    "@folio/eslint-config-stripes": "^5.2.0",
+    "@folio/stripes": "^3.0.0",
+    "@folio/stripes-cli": "^__cliVersion__ || ^1.14.0",
+    "@folio/stripes-core": "^4.0.0",
     "babel-eslint": "^9.0.0",
-    "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
-    "eslint": "^5.6.0",
-    "mocha": "^5.2.0",
-    "react": "^16.4.1",
-    "react-dom": "^16.4.1",
-    "react-redux": "^5.0.7",
+    "eslint": "^6.2.1",
+    "mocha": "^6.1.3",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "react-redux": "^5.1.1",
     "redux": "^4.0.0",
-    "sinon": "^6.3.4"
+    "regenerator-runtime": "^0.13.3",
+    "sinon": "^7.3.2"
   },
   "dependencies": {
     "prop-types": "^15.6.0",
-    "react-intl": "^2.4.0",
-    "react-router-dom": "^4.1.1"
+    "react-intl": "^2.9.0",
+    "react-router-dom": "^4.3.1"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.0.0",
+    "@folio/stripes": "^3.0.0",
     "react": "*"
   },
   "stripes": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/__packageName__",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "__appDescription__",
   "main": "src/index.js",
   "repository": "",

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,6 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import Switch from 'react-router-dom/Switch';

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,9 @@ class __componentName__ extends React.Component {
   static propTypes = {
     match: PropTypes.object.isRequired,
     showSettings: PropTypes.bool,
+    stripes: PropTypes.shape({
+      connect: PropTypes.func
+    })
   };
 
   constructor(props) {

--- a/test/bigtest/index.js
+++ b/test/bigtest/index.js
@@ -1,4 +1,5 @@
-require('regenerator-runtime/runtime');
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 // require all modules ending in "-test" from the current directory and
 // all subdirectories

--- a/test/bigtest/index.js
+++ b/test/bigtest/index.js
@@ -1,4 +1,4 @@
-import 'babel-polyfill';
+require('regenerator-runtime/runtime');
 
 // require all modules ending in "-test" from the current directory and
 // all subdirectories


### PR DESCRIPTION
- Removing `babel-polyfill` since we now have Babel 7 support in FOLIO
- Updating `eslint` to 6.2.1
- Import of `regenerator-runtime` needed in lieu of `babel-polyfill`