### PR TITLE
Refactor to MirageJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.0 (IN PROGRESS)
 
+* Replace `bigtest/mirage` with `miragejs`.
 * Updated to use Babel 7.
 * Updated `stripes` to v3.0.0.
 * Updated `eslint` to v6.2.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## 1.1.0 (IN PROGRESS)
 
-* Replace `bigtest/mirage` with `miragejs`.
 * Updated to use Babel 7.
 * Updated `stripes` to v3.0.0.
 * Updated `eslint` to v6.2.1.
+* Replace `bigtest/mirage` with `miragejs`.
 
 ## 1.0.0 (https://github.com/folio-org/ui-app-template/tree/v1.0.0) (2020-03-02)
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "devDependencies": {
     "@bigtest/interactor": "^0.8.1",
-    "@bigtest/mirage": "^0.0.1",
     "@bigtest/mocha": "^0.5.1",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.2.0",
@@ -27,6 +26,8 @@
     "chai": "^4.2.0",
     "core-js": "^3.6.1",
     "eslint": "^6.2.1",
+    "inflected": "^2.0.4",
+    "miragejs": "^0.1.40",
     "mocha": "^6.1.3",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/test/bigtest/network/index.js
+++ b/test/bigtest/network/index.js
@@ -1,4 +1,4 @@
-import { camelize } from '@bigtest/mirage';
+import { camelize, underscore } from 'inflected';
 
 // auto-import all mirage submodules
 const req = require.context('./', true, /\.js$/);
@@ -8,7 +8,7 @@ const modules = req.keys().reduce((acc, modulePath) => {
   const moduleName = moduleParts[2];
 
   if (moduleName) {
-    const moduleKey = camelize(moduleName.replace('.js', ''));
+    const moduleKey = camelize(underscore(moduleName.replace('.js', '')), false);
 
     return Object.assign(acc, {
       [moduleType]: {


### PR DESCRIPTION
## Motivation
![Screen Shot 2020-07-14 at 4 57 15 PM](https://user-images.githubusercontent.com/29791650/87475647-25324e00-c5f3-11ea-91b6-6d53fdfacdf4.png)
This is part of an on-going initiative to completely migrate all of `folio-org` projects from `@bigtest/mirage` to `miragejs`.

[`@bigtest/mirage`](https://github.com/bigtestjs/mirage/) was originally a prototype to make `mirage` available to any framework, but it has since been archived in favor of [`miragejs`](https://miragejs.com/). The documentation for `miragejs` is not only prodigious for its extensive API docs but also for its tutorials and guides. Furthermore, it receives regular bug-fixes and maintenance releases in thanks to its extremely large and active community.

Previous PR: [@folio-org/ui-agreements #565](https://github.com/folio-org/ui-agreements/pull/565)
_Linking the previous pull request so that subsequent ones can be found tagged below._

<details>
<summary>Overview of progress at the time of the creation of this PR (in chronological order):</summary>
<br>
✅ <code>ui-checkin</code>
<br>
☑️ <code>ui-checkout</code>
<br>
☑️ <code>ui-circulation</code>
<br>
☑️ <code>ui-calendar</code>
<br>
☑️ <code>ui-agreements</code>
<br>
☑️ <code>ui-app-template</code>
</details>

## Approach
- [x] Cloned, installed, and then ran tests to double check that the tests are passing before refactoring.
- [x] Removed `@bigtest/mirage` and added `inflected` and `miragejs`.
  - This refactor was much simpler as there were no actual code and only a template as the name suggests.
  - Although `miragejs` isn't actually utilized, I added it in the spirit of making this a useful template.
- [x] Ran tests after the refactor to confirm they all pass.