### PR TITLE
STCLI-172 use stripes-v6 era dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,7 @@
 
 ## 1.1.0 (IN PROGRESS)
 
-* Updated to use Babel 7.
-* Updated `stripes` to v3.0.0.
-* Updated `eslint` to v6.2.1.
-* Replace `bigtest/mirage` with `miragejs`.
 
-## 1.0.0 (https://github.com/folio-org/ui-app-template/tree/v1.0.0) (2020-03-02)
+## 1.0.0
 
 * New app created with stripes-cli

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # __uiAppName__
 
-Copyright (C) 2020 The Open Library Foundation
+Copyright (C) 2021 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License, Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 

--- a/package.json
+++ b/package.json
@@ -49,10 +49,9 @@
     "react-router-dom": "^5.2.0"
   },
   "stripes": {
-    "type": "app",
+    "actsAs": ["app", "settings"],
     "displayName": "ui-__packageName__.meta.title",
     "route": "/__appRoute__",
-    "hasSettings": true,
     "okapiInterfaces": {},
     "permissionSets": [
       {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=12.21.0"
+    "node": ">=12.20.1"
   },
   "scripts": {
     "start": "stripes serve",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=8.9.0"
+    "node": ">=12.21.0"
   },
   "scripts": {
     "start": "stripes serve",
@@ -19,9 +19,9 @@
     "@bigtest/mocha": "^0.5.1",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^5.2.0",
-    "@folio/stripes": "^3.0.0",
-    "@folio/stripes-cli": "^__cliVersion__ || ^1.14.0",
-    "@folio/stripes-core": "^4.0.0",
+    "@folio/stripes": "^6.0.0",
+    "@folio/stripes-cli": "^__cliVersion__ || ^2.0.0",
+    "@folio/stripes-core": "^7.0.0",
     "babel-eslint": "^9.0.0",
     "chai": "^4.2.0",
     "core-js": "^3.6.1",
@@ -29,12 +29,12 @@
     "inflected": "^2.0.4",
     "miragejs": "^0.1.40",
     "mocha": "^6.1.3",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
-    "react-intl": "^2.9.0",
-    "react-redux": "^5.1.1",
-    "react-router-dom": "^4.3.1",
-    "redux": "^4.0.0",
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0",
+    "react-intl": "^5.8.0",
+    "react-redux": "^7.2.2",
+    "react-router-dom": "^5.2.0",
+    "redux": "^4.0.5",
     "regenerator-runtime": "^0.13.3",
     "sinon": "^7.3.2"
   },
@@ -42,11 +42,11 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^3.0.0",
+    "@folio/stripes": "^6.0.0",
     "core-js": "^3.6.1",
     "react": "*",
-    "react-intl": "^2.9.0",
-    "react-router-dom": "^4.3.1"
+    "react-intl": "^5.8.0",
+    "react-router-dom": "^5.2.0"
   },
   "stripes": {
     "type": "app",


### PR DESCRIPTION
Replace outdated versions of `@folio/stripes-*` and others with their
`@folio/stripes` `v6` versions.

h/t @AndrewIsh

Refs [STCLI-172](https://issues.folio.org/browse/STCLI-172)