### PR TITLE
UIAPPTEMP-6 Update react peerDependency to caret dep.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.0 (IN PROGRESS)
 
+* Add caret to react peer dependency.
 
 ## 1.0.0
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@folio/stripes": "^9.0.0",
-    "react": "18.2.0",
+    "react": "^18.3.1",
     "react-intl": "^6.4.4",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "peerDependencies": {
     "@folio/stripes": "^9.0.0",
-    "react": "^18.3.1",
+    "react": "^18.2.0",
     "react-intl": "^6.4.4",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"


### PR DESCRIPTION
As package managers become more strict about peerDependency specifications all being in agreement with eachother, we want apps to have coordinating versions with their anticipated platform to prevent any hiccups while installing. `pnpm` complained about an `18.2.0` hard dependency in a 'newly created' app while the platform, `stripes`, etc, ask for `^18.2.0 ` - (incompatible since the caret pulls in a later version.)

AFAWK, only one module created/affected by this: PR for that module: https://github.com/folio-org/ui-requests-mediated/pull/16 